### PR TITLE
Fix assignments in DiscoveryConfigApiModel.

### DIFF
--- a/src/v2/Models/DiscoveryConfigApiModel.cs
+++ b/src/v2/Models/DiscoveryConfigApiModel.cs
@@ -32,10 +32,10 @@ namespace Microsoft.Azure.IIoT.Modules.OpcUa.Twin.v2.Models {
             NetworkProbeTimeout = model.NetworkProbeTimeout;
             MaxNetworkProbes = model.MaxNetworkProbes;
             PortRangesToScan = model.PortRangesToScan;
-            PortProbeTimeout = PortProbeTimeout;
+            PortProbeTimeout = model.PortProbeTimeout;
             MaxPortProbes = model.MaxPortProbes;
             MinPortProbesPercent = model.MinPortProbesPercent;
-            IdleTimeBetweenScans = IdleTimeBetweenScans;
+            IdleTimeBetweenScans = model.IdleTimeBetweenScans;
             Callbacks = model.Callbacks?
                 .Select(c => c == null ? null : new CallbackApiModel(c))
                 .ToList();


### PR DESCRIPTION
The DiscoveryConfigApiModel constructor takes a model and copies over fields from it, but two lines appear to do nothing (maybe a typo?):

```
ProbePortTimeout = ProbePortTimeout;
...
IdleTimeBetweenScans = IdleTimeBetweenscans;
```

I haven't tested this, and have no idea if this was done intentionally.